### PR TITLE
Fixed unmute problem using a toggle-master function

### DIFF
--- a/volume-control.lua
+++ b/volume-control.lua
@@ -144,6 +144,12 @@ function vcontrol:toggle()
     self:update(self:mixercommand("set", self.channel, "toggle"))
 end
 
+function vcontrol:toggle_master()
+    self:update(self:mixercommand("set", "Master", "toggle"))
+    self:update(self:mixercommand("set", "Headphone", "unmute"))
+    self:update(self:mixercommand("set", "Speaker", "unmute"))
+end
+
 function vcontrol:mute()
     self:update(self:mixercommand("set", "Master", "mute"))
 end


### PR DESCRIPTION
Initial issue:

When using the `toggle` function, mute worked as expected.
When unmuting with the `toggle` function, the **master** would be unmuted but the specific **output devices** wouldn't (I had to manually unmute them using _pavucontrol_).

Solution:
On `toggle_master`, mute/unmute the **master** but always let **output devices** unmuted.